### PR TITLE
Add Player Respawn

### DIFF
--- a/Assets/Prefabs/Main/Managers/GameManager.prefab
+++ b/Assets/Prefabs/Main/Managers/GameManager.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2052934134009988858}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -45,3 +45,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   player: {fileID: 0}
+  enemyAI: {fileID: 0}
+  countdownTimer: {fileID: 0}
+  DefaultRespawnPosition: {x: -91.3, y: 1, z: -97.8}

--- a/Assets/Sandbox/Uchiyama/Scenes/MainScene_u.unity
+++ b/Assets/Sandbox/Uchiyama/Scenes/MainScene_u.unity
@@ -353,8 +353,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b02ef6eec65b442748b19007077a90a2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  CountdownDuration: 60
-  timerText: {fileID: 0}
+  countDownDuration: 80
+  timerText: {fileID: 1103557791}
 --- !u!1001 &295842230
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -437,18 +437,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6034626642155126375, guid: 19236cbb32d8e4156878121eb1701576, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 19236cbb32d8e4156878121eb1701576, type: 3}
---- !u!224 &299328770 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7592090827493774473, guid: c5bd990a06c1042b49b241c6641c94ce, type: 3}
-  m_PrefabInstance: {fileID: 1412241353}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &309079850 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5067676933441973044, guid: 8e0ca241b87f04648b2ec51650b6608e, type: 3}
@@ -566,6 +561,11 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 1880311680}
   m_SourcePrefab: {fileID: 100100000, guid: d5693708415eb48aeb7e53940c13e219, type: 3}
+--- !u!4 &526458856 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8074969920645438858, guid: 333c5d12783cc6a408cb3df8d3d22907, type: 3}
+  m_PrefabInstance: {fileID: 843889825}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &540582297 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1936125210050109888, guid: 333c5d12783cc6a408cb3df8d3d22907, type: 3}
@@ -644,142 +644,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8f903c0fd5f22470b8299c713c7fa6e6, type: 3}
---- !u!1 &564951851
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 564951852}
-  - component: {fileID: 564951854}
-  - component: {fileID: 564951853}
-  m_Layer: 5
-  m_Name: CountDownTimer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &564951852
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 564951851}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 299328770}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -360, y: 240}
-  m_SizeDelta: {x: 200, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &564951853
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 564951851}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Timer
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 40
-  m_fontSizeBase: 40
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 1
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &564951854
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 564951851}
-  m_CullTransparentMesh: 1
 --- !u!4 &602605626 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6541932862363374700, guid: 333c5d12783cc6a408cb3df8d3d22907, type: 3}
@@ -922,7 +786,8 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 2116801345075746111, guid: 333c5d12783cc6a408cb3df8d3d22907, type: 3}
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 6005823117864029443, guid: 333c5d12783cc6a408cb3df8d3d22907, type: 3}
       insertIndex: 11
@@ -1142,7 +1007,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3935310138754294399, guid: 53a717c9050e34307b93f5e777290533, type: 3}
       propertyPath: isHorizontalInverted
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7433976897722441484, guid: 53a717c9050e34307b93f5e777290533, type: 3}
       propertyPath: m_Name
@@ -1158,6 +1023,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2508567888484873810, guid: 53a717c9050e34307b93f5e777290533, type: 3}
   m_PrefabInstance: {fileID: 997455249}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1103557791 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7928103422811979105, guid: c5bd990a06c1042b49b241c6641c94ce, type: 3}
+  m_PrefabInstance: {fileID: 1412241353}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &1108163945 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6451966002160712461, guid: 8f903c0fd5f22470b8299c713c7fa6e6, type: 3}
@@ -1293,10 +1169,7 @@ PrefabInstance:
     - {fileID: 8562643480285735996, guid: c5bd990a06c1042b49b241c6641c94ce, type: 3}
     m_RemovedGameObjects:
     - {fileID: 8299755002931656730, guid: c5bd990a06c1042b49b241c6641c94ce, type: 3}
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 7592090827493774473, guid: c5bd990a06c1042b49b241c6641c94ce, type: 3}
-      insertIndex: 3
-      addedObject: {fileID: 564951852}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c5bd990a06c1042b49b241c6641c94ce, type: 3}
 --- !u!114 &1432960161 stripped
@@ -1709,6 +1582,38 @@ PrefabInstance:
       propertyPath: enemyAI
       value: 
       objectReference: {fileID: 1638045983}
+    - target: {fileID: 8785554058055454799, guid: e7960efeaae96482da914062fc0009be, type: 3}
+      propertyPath: countdownTimer
+      value: 
+      objectReference: {fileID: 128876805}
+    - target: {fileID: 8785554058055454799, guid: e7960efeaae96482da914062fc0009be, type: 3}
+      propertyPath: RespawnPosition
+      value: 
+      objectReference: {fileID: 526458856}
+    - target: {fileID: 8785554058055454799, guid: e7960efeaae96482da914062fc0009be, type: 3}
+      propertyPath: finalSpawnPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8785554058055454799, guid: e7960efeaae96482da914062fc0009be, type: 3}
+      propertyPath: finalSpawnPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8785554058055454799, guid: e7960efeaae96482da914062fc0009be, type: 3}
+      propertyPath: finalSpawnPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8785554058055454799, guid: e7960efeaae96482da914062fc0009be, type: 3}
+      propertyPath: DefaultRespawnPosition.x
+      value: -91.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8785554058055454799, guid: e7960efeaae96482da914062fc0009be, type: 3}
+      propertyPath: DefaultRespawnPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8785554058055454799, guid: e7960efeaae96482da914062fc0009be, type: 3}
+      propertyPath: DefaultRespawnPosition.z
+      value: -97.8
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scripts/Enemy/EnemyAI.cs
+++ b/Assets/Scripts/Enemy/EnemyAI.cs
@@ -88,7 +88,8 @@ public class EnemyAI : MonoBehaviour
     [SerializeField] private float respawnSearchRadius = 2f;
     // 常にアクティブな床のレイヤー
     [SerializeField] private LayerMask FloorLayer; 
-    [SerializeField] private LayerMask disappearFloorLayer; // 消える床のレイヤー
+    // 消える床のレイヤー
+    [SerializeField] private LayerMask disappearFloorLayer; 
 
 
     private void Awake()

--- a/Assets/Scripts/MapObject/GameOverArea.cs
+++ b/Assets/Scripts/MapObject/GameOverArea.cs
@@ -14,7 +14,8 @@ public class GameOverArea : MonoBehaviour
         if (other.TryGetComponent<Player>(out _))
         {
             Debug.Log("Entered!!");
-            GameManager.Instance.GameOver();
+            // GameManager.Instance.GameOver();
+            GameManager.Instance.Fall();
         }
         else if (other.TryGetComponent<Enemy>(out _))
         {

--- a/Assets/Scripts/MapObject/Item.cs
+++ b/Assets/Scripts/MapObject/Item.cs
@@ -80,13 +80,9 @@ public class Item : MonoBehaviour
         {
             // 表示状態の時のみ取得可能
             if (!_isVisible) return;
-            
-            GameManager.Instance.AddItemCount();
-            
-            // アイテムとった座標をPlayerPrefsに登録して、プレイヤーのリスポーン地点とする
-            PlayerPrefs.SetFloat("RespawnPosition_x", this.transform.position.x);
-            PlayerPrefs.SetFloat("RespawnPosition_y", this.transform.position.y);
-            PlayerPrefs.SetFloat("RespawnPosition_z", this.transform.position.z);
+
+            // アイテムとった座標をGameManagerに渡して、プレイヤーのリスポーン地点にする。
+            GameManager.Instance.AddItemCount(new Vector3(transform.position.x,transform.position.y,transform.position.z));
             
             Destroy(gameObject);
         }

--- a/Assets/Scripts/MapObject/Item.cs
+++ b/Assets/Scripts/MapObject/Item.cs
@@ -82,7 +82,7 @@ public class Item : MonoBehaviour
             if (!_isVisible) return;
 
             // アイテムとった座標をGameManagerに渡して、プレイヤーのリスポーン地点にする。
-            GameManager.Instance.AddItemCount(new Vector3(transform.position.x,transform.position.y,transform.position.z));
+            GameManager.Instance.AddItemCount(transform);
             
             Destroy(gameObject);
         }

--- a/Assets/Scripts/MapObject/Item.cs
+++ b/Assets/Scripts/MapObject/Item.cs
@@ -82,6 +82,12 @@ public class Item : MonoBehaviour
             if (!_isVisible) return;
             
             GameManager.Instance.AddItemCount();
+            
+            // アイテムとった座標をPlayerPrefsに登録して、プレイヤーのリスポーン地点とする
+            PlayerPrefs.SetFloat("RespawnPosition_x", this.transform.position.x);
+            PlayerPrefs.SetFloat("RespawnPosition_y", this.transform.position.y);
+            PlayerPrefs.SetFloat("RespawnPosition_z", this.transform.position.z);
+            
             Destroy(gameObject);
         }
     }

--- a/Assets/Scripts/System/CountdownTimer.cs
+++ b/Assets/Scripts/System/CountdownTimer.cs
@@ -3,11 +3,11 @@
 /// </summary>
 /// 開発進捗
 /// 06/11:作成
-/// 06/16:
+/// 06/16:ゲームオーバー時のペナルティで残り時間を減少させるように修正
+/// 06/17:機微の修正
 
 using UnityEngine;
 using TMPro;
-using UnityEngine.SceneManagement; // シーン管理のために必要
 
 public class CountdownTimer : MonoBehaviour
 {
@@ -41,7 +41,7 @@ public class CountdownTimer : MonoBehaviour
         if (_wasGameEnded) return; 
 
         // 残り時間を数える
-        OperateCurrentTime(-Time.deltaTime);
+        DecreaseCurrentTime(Time.deltaTime);
         // タイマーを更新
         SetTimeDisplay();
         // 時間が0秒以下でゲームオーバー
@@ -72,11 +72,11 @@ public class CountdownTimer : MonoBehaviour
     }
 
     /// <summary>
-    /// 残り時間を変更するメソッド
+    /// 残り時間を減らすメソッド
     /// </summary>
-    public void OperateCurrentTime(float v)
+    public void DecreaseCurrentTime(float v)
     {
-        _currentTime += v;
+        _currentTime -= Mathf.Abs(v);
     }
 
     /// <summary>

--- a/Assets/Scripts/System/CountdownTimer.cs
+++ b/Assets/Scripts/System/CountdownTimer.cs
@@ -3,6 +3,7 @@
 /// </summary>
 /// 開発進捗
 /// 06/11:作成
+/// 06/16:
 
 using UnityEngine;
 using TMPro;
@@ -17,7 +18,9 @@ public class CountdownTimer : MonoBehaviour
     // 現在の残り時間
     private float _currentTime;
     // ゲーム終了（ゲームオーバーまたはクリア）を判定するフラグ
-    private bool _wasGameEnded = false; 
+    private bool _wasGameEnded = false;
+    // PlayerPrefsに登録する残り時間のキー
+    private const string REMAINING_TIME_AT_CLEAR = "RemainingTimeAtClear";
 
     /// <summary>
     /// ゲーム開始時に、初期時間をタイマーに反映させる
@@ -37,15 +40,14 @@ public class CountdownTimer : MonoBehaviour
         // ゲームが終了していたら更新しない
         if (_wasGameEnded) return; 
 
-        // タイマーを数える
-        _currentTime -= Time.deltaTime;
+        // 残り時間を数える
+        OperateCurrentTime(-Time.deltaTime);
         // タイマーを更新
         SetTimeDisplay();
         // 時間が0秒以下でゲームオーバー
         if (_currentTime <= 0f)
         {
-            // 0秒で固定
-            _currentTime = 0f;
+            _currentTime = 0f; //0秒で固定
 
             Debug.Log("タイマーが0秒になりました");
 
@@ -63,10 +65,18 @@ public class CountdownTimer : MonoBehaviour
     private void SetTimeDisplay()
     {
         // 残り時間を分秒で計算する(かならず0以上にする)
-        int minutes = Mathf.Max(0,Mathf.FloorToInt(_currentTime / 60));
+        int minutes = Mathf.Max(0, Mathf.FloorToInt(_currentTime / 60));
         int seconds = Mathf.Max(0, Mathf.FloorToInt(_currentTime % 60));
         // 表示形式をM分S秒に揃える
         timerText.text = $"{minutes:00}:{seconds:00}";
+    }
+
+    /// <summary>
+    /// 残り時間を変更するメソッド
+    /// </summary>
+    public void OperateCurrentTime(float v)
+    {
+        _currentTime += v;
     }
 
     /// <summary>
@@ -77,7 +87,7 @@ public class CountdownTimer : MonoBehaviour
         SetTimeDisplay();
 
         // PlayerPrefsに残り時間を保存
-        PlayerPrefs.SetFloat(PlayerPrefsKeys.RemainingTimeAtClear, _currentTime);
+        PlayerPrefs.SetFloat(REMAINING_TIME_AT_CLEAR, _currentTime);
         PlayerPrefs.Save();
 
         Debug.Log($"クリア時の残り時間としてPlayerPrefsに保存しました: {_currentTime:F2}秒");

--- a/Assets/Scripts/System/GameManager.cs
+++ b/Assets/Scripts/System/GameManager.cs
@@ -23,6 +23,18 @@ public class GameManager : SingletonMonoBehaviour<GameManager>
     
     public Player Player => player;
 
+    private readonly float _fallTimePenalty = -20f;
+
+    private Rigidbody _playerqRigidbody;
+
+    [SerializeField] private Vector3 DefaultRespawnPosition; // デフォルトの復活地点（スタート地点）
+    private Vector3 _respawnPosition;
+
+    // PlayerPrefsから最後に取得したアイテムを読み込むためのキー
+    private const string RESPAWN_POSITION_X = "RespawnPosition_x";
+    private const string RESPAWN_POSITION_Y = "RespawnPosition_y";
+    private const string RESPAWN_POSITION_Z = "RespawnPosition_z";
+
     public void AddItemCount()
     {
         _itemCount.Value++;
@@ -39,6 +51,59 @@ public class GameManager : SingletonMonoBehaviour<GameManager>
         Debug.Log("Game Over");
         SceneManager.LoadScene("GameOverScene");
     }
+    
+    public void Fall()
+    {
+        Debug.Log("Fall Penalty: " + _fallTimePenalty);
+        // 残り時間を減らしてプレイヤーをリスポーンさせる
+        countdownTimer.OperateCurrentTime(_fallTimePenalty);
+        this.RespownPlayer();
+    }
+
+    private void RespownPlayer()
+    {
+        // playerのRigidbodyを束縛する
+        _playerqRigidbody = player.GetComponent<Rigidbody>();
+        if (_playerqRigidbody != null)
+        {
+            Debug.Log("Respowning Player");
+
+            // 座標それぞれのキーが設定されているか確認
+            if (PlayerPrefs.HasKey(RESPAWN_POSITION_X) && PlayerPrefs.HasKey(RESPAWN_POSITION_Y) && PlayerPrefs.HasKey(RESPAWN_POSITION_Z))
+            {
+                // 保存された座標を読み込む
+                float x = PlayerPrefs.GetFloat(RESPAWN_POSITION_X);
+                float y = PlayerPrefs.GetFloat(RESPAWN_POSITION_Y);
+                float z = PlayerPrefs.GetFloat(RESPAWN_POSITION_Z);
+                _respawnPosition = new Vector3(x, y, z);
+                Debug.Log($"リスポーン地点: 最後に拾ったアイテムの位置 ({_respawnPosition})");
+
+            } 
+            else //まだアイテムを取得していない場合
+            { 
+                _respawnPosition = DefaultRespawnPosition;
+                Debug.Log($"リスポーン地点: 初期リスポーン地点（{DefaultRespawnPosition}） を使用します。");
+            }
+            
+            
+            // リスポーン地点に移動させる
+            _playerqRigidbody.transform.position = _respawnPosition;
+            // 速度と慣性をリセット
+            _playerqRigidbody.linearVelocity = Vector3.zero;
+            _playerqRigidbody.angularVelocity = Vector3.zero;
+        }
+    }
+
+    private void ResetRespawnPosition()
+    {
+         // 前回のリスポーン地点を初期化（キーがあれば削除する）
+        if (PlayerPrefs.HasKey(RESPAWN_POSITION_X)) {PlayerPrefs.DeleteKey(RESPAWN_POSITION_X);}
+        if (PlayerPrefs.HasKey(RESPAWN_POSITION_Y)) {PlayerPrefs.DeleteKey(RESPAWN_POSITION_Y);}
+        if (PlayerPrefs.HasKey(RESPAWN_POSITION_Z)) {PlayerPrefs.DeleteKey(RESPAWN_POSITION_Z);}
+        // 削除後、変更をディスクに保存
+        PlayerPrefs.Save();
+        Debug.Log("ゲーム開始時に、前回のリスポーン位置をリセットしました。");
+    }   
 
     // アイテムカウントによるゲームクリア処理
     public void GameClear()
@@ -60,6 +125,9 @@ public class GameManager : SingletonMonoBehaviour<GameManager>
         ClosestEnemyDistance = ObservableExtensions
             .Select(Observable.EveryUpdate(), _ => Vector3.Distance(player.transform.position, enemyAI.transform.position))
             .ToReadOnlyReactiveProperty(float.MaxValue);
+
+        // スポーン地点をデフォルトスポーン地点に初期化
+        ResetRespawnPosition();
     }
 
     private void Update()

--- a/Assets/Scripts/System/GameManager.cs
+++ b/Assets/Scripts/System/GameManager.cs
@@ -31,10 +31,10 @@ public class GameManager : SingletonMonoBehaviour<GameManager>
   [SerializeField] private Vector3 defaultRespawnPosition;
   private Vector3 _respawnPosition;
 
-  public void AddItemCount(Vector3 itemPositon)
+  public void AddItemCount(Transform itemPositon)
   {
     _itemCount.Value++;
-    _respawnPosition = itemPositon; //最後に取得したアイテムの位置をリスポーン地点にする
+    _respawnPosition = new Vector3(itemPositon.position.x,itemPositon.position.y,itemPositon.position.z); //最後に取得したアイテムの位置をリスポーン地点にする
     if (_itemCount.Value >= 5)
     {
       // クリア時の残りタイムを保存する
@@ -53,7 +53,7 @@ public class GameManager : SingletonMonoBehaviour<GameManager>
   {
     Debug.Log("Fall Penalty: " + _fallTimePenalty);
     // 残り時間を減らしてプレイヤーをリスポーンさせる
-    countdownTimer.OperateCurrentTime(_fallTimePenalty);
+    countdownTimer.DecreaseCurrentTime(_fallTimePenalty);
     RespownPlayer();
   }
 

--- a/Assets/Scripts/System/GameManager.cs
+++ b/Assets/Scripts/System/GameManager.cs
@@ -7,102 +7,74 @@ using System;
 
 public class GameManager : SingletonMonoBehaviour<GameManager>
 {
-    [Tooltip("プレイヤーの参照。ゲーム開始時に設定する必要があります")]
-    [SerializeField] private Player player;
-    [Tooltip("敵の参照。ゲーム開始時に設定する必要があります")]
-    [SerializeField] private EnemyAI enemyAI;
+  [Tooltip("プレイヤーの参照。ゲーム開始時に設定する必要があります")] [SerializeField]
+  private Player player;
 
-    [Tooltip ("カウントダウンタイマーの参照。ゲーム開始時に設定する必要があります")]
-    [SerializeField] private CountdownTimer countdownTimer;
+  [Tooltip("敵の参照。ゲーム開始時に設定する必要があります")] [SerializeField]
+  private EnemyAI enemyAI;
 
-    public ReadOnlyReactiveProperty<int> ItemCount => _itemCount;
-        
-    private readonly ReactiveProperty<int> _itemCount = new(0);
+  [Tooltip("カウントダウンタイマーの参照。ゲーム開始時に設定する必要があります")] [SerializeField]
+  private CountdownTimer countdownTimer;
 
-    public ReadOnlyReactiveProperty<float> ClosestEnemyDistance { get; private set; }
-    
-    public Player Player => player;
+  public ReadOnlyReactiveProperty<int> ItemCount => _itemCount;
 
-    private readonly float _fallTimePenalty = -20f;
+  private readonly ReactiveProperty<int> _itemCount = new(0);
 
-    private Rigidbody _playerqRigidbody;
+  public ReadOnlyReactiveProperty<float> ClosestEnemyDistance { get; private set; }
 
-    [SerializeField] private Vector3 DefaultRespawnPosition; // デフォルトの復活地点（スタート地点）
-    private Vector3 _respawnPosition;
+  public Player Player => player;
 
-    // PlayerPrefsから最後に取得したアイテムを読み込むためのキー
-    private const string RESPAWN_POSITION_X = "RespawnPosition_x";
-    private const string RESPAWN_POSITION_Y = "RespawnPosition_y";
-    private const string RESPAWN_POSITION_Z = "RespawnPosition_z";
+  private readonly float _fallTimePenalty = -20f;
 
-    public void AddItemCount()
+  private Rigidbody _playerqRigidbody;
+
+  [SerializeField] private Vector3 defaultRespawnPosition;
+  private Vector3 _respawnPosition;
+
+  public void AddItemCount(Vector3 itemPositon)
+  {
+    _itemCount.Value++;
+    _respawnPosition = itemPositon; //最後に取得したアイテムの位置をリスポーン地点にする
+    if (_itemCount.Value >= 5)
     {
-        _itemCount.Value++;
-        if (_itemCount.Value >= 5)
-        {
-            // クリア時の残りタイムを保存する
-            countdownTimer.SaveCurrentTime();
-            GameClear();
-        }
+      // クリア時の残りタイムを保存する
+      countdownTimer.SaveCurrentTime();
+      GameClear();
     }
+  }
 
-    public void GameOver()
-    {
-        Debug.Log("Game Over");
-        SceneManager.LoadScene("GameOverScene");
-    }
-    
-    public void Fall()
-    {
-        Debug.Log("Fall Penalty: " + _fallTimePenalty);
-        // 残り時間を減らしてプレイヤーをリスポーンさせる
-        countdownTimer.OperateCurrentTime(_fallTimePenalty);
-        this.RespownPlayer();
-    }
+  public void GameOver()
+  {
+    Debug.Log("Game Over");
+    SceneManager.LoadScene("GameOverScene");
+  }
 
-    private void RespownPlayer()
-    {
-        // playerのRigidbodyを束縛する
-        _playerqRigidbody = player.GetComponent<Rigidbody>();
-        if (_playerqRigidbody != null)
-        {
-            Debug.Log("Respowning Player");
+  public void Fall()
+  {
+    Debug.Log("Fall Penalty: " + _fallTimePenalty);
+    // 残り時間を減らしてプレイヤーをリスポーンさせる
+    countdownTimer.OperateCurrentTime(_fallTimePenalty);
+    RespownPlayer();
+  }
 
-            // 座標それぞれのキーが設定されているか確認
-            if (PlayerPrefs.HasKey(RESPAWN_POSITION_X) && PlayerPrefs.HasKey(RESPAWN_POSITION_Y) && PlayerPrefs.HasKey(RESPAWN_POSITION_Z))
-            {
-                // 保存された座標を読み込む
-                float x = PlayerPrefs.GetFloat(RESPAWN_POSITION_X);
-                float y = PlayerPrefs.GetFloat(RESPAWN_POSITION_Y);
-                float z = PlayerPrefs.GetFloat(RESPAWN_POSITION_Z);
-                _respawnPosition = new Vector3(x, y, z);
-                Debug.Log($"リスポーン地点: 最後に拾ったアイテムの位置 ({_respawnPosition})");
+  private void RespownPlayer()
+  {
+    // playerのRigidbodyを束縛する
+    _playerqRigidbody = player.GetComponent<Rigidbody>();
 
-            } 
-            else //まだアイテムを取得していない場合
-            { 
-                _respawnPosition = DefaultRespawnPosition;
-                Debug.Log($"リスポーン地点: 初期リスポーン地点（{DefaultRespawnPosition}） を使用します。");
-            }
-            
-            
-            // リスポーン地点に移動させる
-            _playerqRigidbody.transform.position = _respawnPosition;
-            // 速度と慣性をリセット
-            _playerqRigidbody.linearVelocity = Vector3.zero;
-            _playerqRigidbody.angularVelocity = Vector3.zero;
-        }
-    }
+    Debug.Log($"リスポーン地点: 最後に拾ったアイテムの位置 ({_respawnPosition})");
 
+    // リスポーン地点に移動させる
+    _playerqRigidbody.transform.position = _respawnPosition;
+    // 速度と慣性をリセット
+    _playerqRigidbody.linearVelocity = Vector3.zero;
+    _playerqRigidbody.angularVelocity = Vector3.zero;
+  }
     private void ResetRespawnPosition()
-    {
-         // 前回のリスポーン地点を初期化（キーがあれば削除する）
-        if (PlayerPrefs.HasKey(RESPAWN_POSITION_X)) {PlayerPrefs.DeleteKey(RESPAWN_POSITION_X);}
-        if (PlayerPrefs.HasKey(RESPAWN_POSITION_Y)) {PlayerPrefs.DeleteKey(RESPAWN_POSITION_Y);}
-        if (PlayerPrefs.HasKey(RESPAWN_POSITION_Z)) {PlayerPrefs.DeleteKey(RESPAWN_POSITION_Z);}
-        // 削除後、変更をディスクに保存
-        PlayerPrefs.Save();
-        Debug.Log("ゲーム開始時に、前回のリスポーン位置をリセットしました。");
+    {        
+        // 初期リスポーン地点を設定
+        _respawnPosition = defaultRespawnPosition;
+        Debug.Log("初期リスポーン位置をセットしました。");
     }   
 
     // アイテムカウントによるゲームクリア処理
@@ -126,7 +98,7 @@ public class GameManager : SingletonMonoBehaviour<GameManager>
             .Select(Observable.EveryUpdate(), _ => Vector3.Distance(player.transform.position, enemyAI.transform.position))
             .ToReadOnlyReactiveProperty(float.MaxValue);
 
-        // スポーン地点をデフォルトスポーン地点に初期化
+        // スポーン地点を初期化
         ResetRespawnPosition();
     }
 

--- a/Assets/Scripts/UI/RemainingTimeText.cs
+++ b/Assets/Scripts/UI/RemainingTimeText.cs
@@ -7,10 +7,15 @@
 using UnityEngine;
 using TMPro; // TextMeshProUGUI を使う場合
 
+
 public class RemainingTimeText : MonoBehaviour
 {
     // UIのTextMeshProの束縛
     [SerializeField] private TextMeshProUGUI remainingTimeText;
+    // PlayerPrefsに登録された残り時間のキー
+    private const string REMAINING_TIME_AT_CLEAR = "RemainingTimeAtClear";
+    // 残り時間（デフォルトは0）
+    private float _remainingTime = 0;
 
     private void Start()
     {
@@ -18,30 +23,33 @@ public class RemainingTimeText : MonoBehaviour
         DisplayRemainingTime();
     }
 
-    void DisplayRemainingTime()
+    private void DisplayRemainingTime()
     {
-        // PlayerPrefsから残り時間を読み込み
-        // キーが存在しない場合はデフォルト値として0fを返す
-        float time = PlayerPrefs.GetFloat(PlayerPrefsKeys.RemainingTimeAtClear, 0f);
+        // PlayerPrefsから残り時間を読み込み（デフォルトは0f）
+        if (PlayerPrefs.HasKey(REMAINING_TIME_AT_CLEAR))
+        {
+            _remainingTime = Mathf.Max(0f, PlayerPrefs.GetFloat(REMAINING_TIME_AT_CLEAR));
+            // 残り時間を表示した後は、PlayerPrefsのデータをクリアする
+            PlayerPrefs.DeleteKey(REMAINING_TIME_AT_CLEAR);
+            PlayerPrefs.Save();
+        }
         
-        // 読み込んだ時間が0より大きい場合のみ表示（デフォルト値でないことを確認）
-        if (time >= 0)
+        // 読み込んだ時間が0以上の場合のみ表示
+        if (_remainingTime >= 0)
         {
             // "残りタイム: MM:SS" の形式で表示
-            int minutes = Mathf.FloorToInt(time / 60);
-            int seconds = Mathf.FloorToInt(time % 60);            
+            int minutes = Mathf.FloorToInt(_remainingTime / 60);
+            int seconds = Mathf.FloorToInt(_remainingTime % 60);            
             remainingTimeText.text = $"Time: {minutes:00}:{seconds:00}";
             
             // デバッグ用
-            Debug.Log($"クリアシーンでPlayerPrefsから読み込んだ残りタイム: {time:F2}秒");
+            Debug.Log($"クリアシーンで読み込んだクリア時残りタイム: {_remainingTime:F2}秒");
         }
         else
         {
-            Debug.LogWarning("PlayerPrefsに残り時間のデータが見つからないか、値が0以下です。");
+            Debug.LogWarning("PlayerPrefsに残り時間のデータが見つからないか、値が0未満で登録されています。");
         }
         
-        // 残り時間を表示した後は、PlayerPrefsのデータをクリアする
-        PlayerPrefs.DeleteKey(PlayerPrefsKeys.RemainingTimeAtClear);
-        PlayerPrefs.Save();
+        
     }
 }

--- a/Assets/Scripts/Util/PlayerPrefsKeys.cs
+++ b/Assets/Scripts/Util/PlayerPrefsKeys.cs
@@ -3,5 +3,10 @@ using UnityEngine;
 
 public static class PlayerPrefsKeys // staticクラスとして定義
 {
-    public const string RemainingTimeAtClear = "RemainingTimeAtClear"; // 残り時間を保存するキー
+    // 残り時間を保存するキー
+    // public const string RemainingTimeAtClear = "RemainingTimeAtClear"; 
+    // 最後に取得したアイテムの座標がリスポーン地点
+    // public const string RespawnPosition_x = "RespawnPosition_x";
+    // public const string RespawnPosition_y = "RespawnPosition_y";
+    // public const string RespawnPosition_z = "RespawnPosition_z";
 }

--- a/Assets/Scripts/Util/PlayerPrefsKeys.cs
+++ b/Assets/Scripts/Util/PlayerPrefsKeys.cs
@@ -1,8 +1,0 @@
-// PlayerPrefsKeys.cs
-using UnityEngine;
-
-public static class PlayerPrefsKeys // staticクラスとして定義
-{
-    // 残り時間を保存するキー
-    // public const string RemainingTimeAtClear = "RemainingTimeAtClear"; 
-}

--- a/Assets/Scripts/Util/PlayerPrefsKeys.cs
+++ b/Assets/Scripts/Util/PlayerPrefsKeys.cs
@@ -5,8 +5,4 @@ public static class PlayerPrefsKeys // staticクラスとして定義
 {
     // 残り時間を保存するキー
     // public const string RemainingTimeAtClear = "RemainingTimeAtClear"; 
-    // 最後に取得したアイテムの座標がリスポーン地点
-    // public const string RespawnPosition_x = "RespawnPosition_x";
-    // public const string RespawnPosition_y = "RespawnPosition_y";
-    // public const string RespawnPosition_z = "RespawnPosition_z";
 }

--- a/Assets/Scripts/Util/PlayerPrefsKeys.cs.meta
+++ b/Assets/Scripts/Util/PlayerPrefsKeys.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: b4e2ee8aeb89447fb9c6c73db6f0b76c


### PR DESCRIPTION
# プレイヤーがGameOverAreaに侵入した時に、残り時間を-20秒して、最後に取得したアイテムの場所にリスポーンするようにした。

- GameOverArea.csで、プレイヤーが侵入した時にGameManagerに落下処理をさせるようにした。
- GameManager.csに、落下時にCountdownTimer.csの処理を呼び出して残り時間を減らすようにし、その後プレイヤーをリスポーンさせる処理を追加した。
- リスポーン時には、playerのRigidbodyにアクセスし、最後に取得したアイテムの座標を調べてからリスポーン/速度と完成をリセットするような処理にした。
- 最後に取得したアイテムの座標はItem.csでDestroy時にPlayerPrefsに自分自身の座標を登録させ、GameManagerから呼び出した。
- その際にアイテム未取得の場合は初期リスポーンになるようにGameManagerのAwake時にPlayerPrefsに登録した座標を削除している（でなければ、ゲームごとに登録した座標がリセットされないため）